### PR TITLE
link to active github instead of srouceforge

### DIFF
--- a/README
+++ b/README
@@ -42,8 +42,7 @@ Features:
 
 	
 Homepage:
-	https://sourceforge.net/projects/juffed/
-
+        https://github.com/Mezomish/juffed/
 	
 Bugs and feature requests:
-	https://sourceforge.net/tracker/?group_id=205470
+        https://github.com/Mezomish/juffed/issues

--- a/src/app/ui/JuffMW.cpp
+++ b/src/app/ui/JuffMW.cpp
@@ -65,8 +65,8 @@ AboutDlg* createAboutDlg(QWidget* parent) {
 	QString text = QString("   %1   <br><br>").arg(QObject::tr("Advanced text editor"));
 	text += "   Copyright &copy; 2007-2010 Mikhail Murzin   <br><br>";
 	text += "<a href=\"http://juffed.com/\">http://juffed.com</a><br><br>";
-	text += "<a href=\"http://sourceforge.net/tracker/?group_id=205470&atid=993768\">Report a bug</a><br><br>";
-	text += "<a href=\"http://sourceforge.net/tracker/?group_id=205470&atid=993771\">Request a feature</a>";
+	text += "<a href=\"https://github.com/Mezomish/juffed/issues \">Report a bug</a><br><br>";
+	text += "<a href=\"http:///https://github.com/Mezomish/juffed/issues\">Request a feature</a>";
 	
 	QString auth("<br>&nbsp;Mikhail Murzin a.k.a. Mezomish<br>&nbsp;&nbsp;<a href='mailto:mezomish@gmail.com'>mezomish@gmail.com</a>");
 


### PR DESCRIPTION
Change links in the about dialog and in the readme to point to github which is updated instead of the dead sourceforge page. I did not change the make tarballs as I don't have a place to point that at github.