### PR TITLE
Properly find windres in mingw on Linux.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,7 +273,7 @@ if ( MINGW )
 
     # resource compilation for MinGW
     add_custom_command ( OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/src/app/juffed_ico.o
-        COMMAND windres.exe -I${CMAKE_CURRENT_SOURCE_DIR}/src/app -i${CMAKE_CURRENT_SOURCE_DIR}/src/app/juffed.rc 
+        COMMAND $(WINDRES) -I${CMAKE_CURRENT_SOURCE_DIR}/src/app -i${CMAKE_CURRENT_SOURCE_DIR}/src/app/juffed.rc 
             -o ${CMAKE_CURRENT_BINARY_DIR}/src/app/juffed_ico.o )
     set ( juffed_app_SRCS ${juffed_app_SRCS} ${CMAKE_CURRENT_BINARY_DIR}/src/app/juffed_ico.o)
 endif ( MINGW )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -273,7 +273,7 @@ if ( MINGW )
 
     # resource compilation for MinGW
     add_custom_command ( OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/src/app/juffed_ico.o
-        COMMAND $(WINDRES) -I${CMAKE_CURRENT_SOURCE_DIR}/src/app -i${CMAKE_CURRENT_SOURCE_DIR}/src/app/juffed.rc 
+        COMMAND $ENV{WINDRES} -I${CMAKE_CURRENT_SOURCE_DIR}/src/app -i${CMAKE_CURRENT_SOURCE_DIR}/src/app/juffed.rc 
             -o ${CMAKE_CURRENT_BINARY_DIR}/src/app/juffed_ico.o )
     set ( juffed_app_SRCS ${juffed_app_SRCS} ${CMAKE_CURRENT_BINARY_DIR}/src/app/juffed_ico.o)
 endif ( MINGW )


### PR DESCRIPTION
Mingw sets WINDRES environment variable among others, which can be used to detect windres binary. Fixes building with MinGW on Linux.