### PR TITLE
Fix SymbolBrowser losing symbols and crashing

### DIFF
--- a/plugins/symbolbrowser/symbols/symboltreeview.cpp
+++ b/plugins/symbolbrowser/symbols/symboltreeview.cpp
@@ -182,9 +182,9 @@ void SymbolTreeView::docClosed(const QString &docName){
  *****************************************************************************/
 void SymbolTreeView::docRenamed(const QString &oldDocName, const QString newDocName) {
     DocSymbols *symb = mDocuments.value(oldDocName);
+    mDocuments.remove(oldDocName);
     mDocuments[newDocName] = symb;
     symb->setDocName(newDocName);
-    mDocuments.remove(oldDocName);
     refresh();
 }
 


### PR DESCRIPTION
"Save as" on a file using the old name removed the symbols from the dock of the SymbolBrowser plugin. "Save as" again using the old name caused a crash. Both was because the symbols got lost during "renaming" the file.

Thanks!