### PR TITLE
Fix start crash if file manager plugin is disabled

### DIFF
--- a/plugins/fm/FMPlugin.cpp
+++ b/plugins/fm/FMPlugin.cpp
@@ -20,11 +20,22 @@
 #include "ManageDlg.h"
 #include "TreeView.h"
 
-FMPlugin::FMPlugin() : QObject(), JuffPlugin() {
+FMPlugin::FMPlugin() : QObject(), JuffPlugin()
+, w_(0)
+, tree_(0)
+, model_(0)
+, pathEd_(0)
+, backBtn_(0)
+, favoritesMenu_(0)
+, addToFavoritesAct_(0)
+, manageFavoritesAct_(0)
+{
 	showAsTree = PluginSettings::getBool(this, "ShowAsTree", false);
     showHidden = PluginSettings::getBool(this, "ShowHidden", false);
     sortColumn = PluginSettings::getInt(this, "sortColumn", 0);
+}
 
+void FMPlugin::init() {
 	w_ = new QWidget();
 	w_->setWindowTitle(tr("Files"));
 
@@ -92,10 +103,13 @@ FMPlugin::FMPlugin() : QObject(), JuffPlugin() {
 }
 
 FMPlugin::~FMPlugin() {
-    sortColumn = tree_->header()->sortIndicatorSection();
-    PluginSettings::set(this, "sortColumn", sortColumn);
-
-	w_->deleteLater();
+	if ( tree_ ) {
+		sortColumn = tree_->header()->sortIndicatorSection();
+		PluginSettings::set(this, "sortColumn", sortColumn);
+	}
+	if ( w_ ) {
+		w_->deleteLater();
+	}
 }
 
 QString FMPlugin::name() const {

--- a/plugins/fm/FMPlugin.h
+++ b/plugins/fm/FMPlugin.h
@@ -22,6 +22,8 @@ public:
 	FMPlugin();
 	virtual ~FMPlugin();
 
+	virtual void init();
+
 	//	info
 	virtual QString name() const;
 	virtual QString title() const;


### PR DESCRIPTION
The file manager plugin already created widgets while it was temporarily loaded for getting its attributes on application start. The new `TreeView` widget then caused a crash later because its implementation was unloaded with the deactivated plugin. This was fixed by now creating the widgets in the plugin's `init()` method which is only called for enabled plugins.

This might also fix issue #82.

Thanks!