### PR TITLE
Fix SymbolBrowser getting no symbols and crashing

### DIFF
--- a/src/app/ui/DocViewer.cpp
+++ b/src/app/ui/DocViewer.cpp
@@ -218,6 +218,9 @@ void DocViewer::updateDocTitle(Juff::Document* doc) {
 }
 
 void DocViewer::removeDocFromList(Juff::Document* doc) {
+	if ( curDoc_ == doc ) {
+		curDoc_ = NullDoc::instance();
+	}
 	docStack_.removeAll(doc);
 }
 


### PR DESCRIPTION
If the last document is closed then a new untitled document is created. But this document did no get "activated" and therefore did not get any symbols which in turn led to a null pointer crash when trying to save later. The actual bug was a kept pointer to the previously closed and deleted document. If the new document was accidentally created at the same memory address then it was handled as the old and not "activated".

This may also partially fix issue #67.

Thanks!
