### PR TITLE
Fix build with QScintilla-2.10.3 (?)

### DIFF
--- a/src/app/qsci/lexers/qscilexerada.h
+++ b/src/app/qsci/lexers/qscilexerada.h
@@ -3,9 +3,6 @@
 
 #include <Qsci/qscilexer.h>
 
-// located in SciLexer.h
-#define SCLEX_ADA 20
-
 #define SCE_ADA_DEFAULT 0
 #define SCE_ADA_WORD 1
 #define SCE_ADA_IDENTIFIER 2

--- a/src/app/qsci/lexers/qscilexerhaskell.h
+++ b/src/app/qsci/lexers/qscilexerhaskell.h
@@ -3,9 +3,6 @@
 
 #include <Qsci/qscilexer.h>
 
-// located in SciLexer.h
-#define SCLEX_HASKELL 68
-
 #define SCE_HA_DEFAULT 0
 #define SCE_HA_IDENTIFIER 1
 #define SCE_HA_KEYWORD 2

--- a/src/app/qsci/lexers/qscilexerlisp.h
+++ b/src/app/qsci/lexers/qscilexerlisp.h
@@ -3,9 +3,6 @@
 
 #include <Qsci/qscilexer.h>
 
-// located in SciLexer.h
-#define SCLEX_LISP 21
-
 #define SCE_LISP_DEFAULT 0
 #define SCE_LISP_COMMENT 1
 #define SCE_LISP_NUMBER 2

--- a/src/app/qsci/lexers/qscilexernsis.h
+++ b/src/app/qsci/lexers/qscilexernsis.h
@@ -3,9 +3,6 @@
 
 #include <Qsci/qscilexer.h>
 
-// located in SciLexer.h
-#define SCLEX_NSIS 43
-
 #define SCE_NSIS_DEFAULT 0
 #define SCE_NSIS_COMMENT 1
 #define SCE_NSIS_STRINGDQ 2


### PR DESCRIPTION
These changes were necessary to fix a build issue:
```
juffed-engine-qsci_autogen/HJY3QJUKGU/../../../juffed-0.10_p20160323/src/app/qsci/lexers/qscilexerada.h:7:19: error: expected identifier before numeric constant
 #define SCLEX_ADA 20
                   ^
```
See also: https://bugs.gentoo.org/652928